### PR TITLE
Add extensionKind "ui"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
 	"icon": "icon.png",
 	"version": "0.0.4",
 	"publisher": "slhsxcmy",
+	"extensionKind": [
+        	"ui"
+    	],
 	"engines": {
 		"vscode": "^1.6.0"
 	},


### PR DESCRIPTION
When using the extension with the Remote VSCode mode, this extension is erroneously installed on the remote side.